### PR TITLE
Variable service_name is missing for systemd file

### DIFF
--- a/heka/_service.sls
+++ b/heka/_service.sls
@@ -30,6 +30,8 @@ heka_{{ service_name }}_service_file:
   - source: salt://heka/files/heka.service
   - user: root
   - mode: 644
+  - defaults:
+    service_name: {{ service_name }}
   - template: jinja
 
 {%- else %}


### PR DESCRIPTION
This fixes an issue in the stacklight branch where the `heka_{{ service_name }}_service_file` declaration (systemd) misses the `service_name` default variable.
