### PR TITLE
Use module_dir instead of module_directory

### DIFF
--- a/heka/files/toml/decoder/sandbox.toml
+++ b/heka/files/toml/decoder/sandbox.toml
@@ -1,7 +1,7 @@
 [{{ decoder_name }}_decoder]
 type = "SandboxDecoder"
 filename = "{{ decoder.module_file }}"
-{%- if decoder.module_directory is defined %}
+{%- if decoder.module_dir is defined %}
 module_directory = "{{ decoder.module_dir }}"
 {%- endif %}
 {%- if decoder.memory_limit is defined %}

--- a/heka/files/toml/filter/sandbox.toml
+++ b/heka/files/toml/filter/sandbox.toml
@@ -1,7 +1,7 @@
 [{{ filter_name }}_filter]
 type = "SandboxFilter"
 filename = "{{ filter.module_file }}"
-{%- if filter.module_directory is defined %}
+{%- if filter.module_dir is defined %}
 module_directory = "{{ filter.module_dir }}"
 {%- endif %}
 {%- if filter.message_matcher is defined %}


### PR DESCRIPTION
This fixes a bug where `module_directory` is used as the variable name instead of
`module_dir`.
