### PR TITLE
Add the extra_fields.lua module

### DIFF
--- a/heka/files/lua/common/extra_fields.lua
+++ b/heka/files/lua/common/extra_fields.lua
@@ -1,0 +1,20 @@
+-- Copyright 2015 Mirantis, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+local M = {}
+setfenv(1, M) -- Remove external access to contain everything in the module
+
+-- list of fields that are added to Heka messages by the collector
+tags = {}
+
+return M


### PR DESCRIPTION
This commit adds the `extra_fields` Lua module. The extra fields table defined in this module is empty right now. Eventually, this file will be a Jinja2 template and the content of the extra fields table will be generated based on the user configuration.
