### PR TITLE
Make Heka send metrics to InfluxDB

### DIFF
--- a/heka/_service.sls
+++ b/heka/_service.sls
@@ -149,17 +149,16 @@ heka_{{ service_name }}_service:
 {% if salt['pillar.get']('heka:'+service_grain_name) %}
 
 {%- for service_action_name, service_action in service_grain.iteritems() %}
-{%- if salt['pillar.get']('heka:'+service_grain_name).get(service_action_name, False) is mapping %}
+{%- if salt['pillar.get']('heka:'+service_grain_name).get(service_action_name, None) is mapping %}
+
 {%- set grain_action_meta = salt['pillar.get']('heka:'+service_grain_name+':'+service_action_name) %}
-{#
-{%- set service_grains.get(service_grain_name).get(service_action_name) = salt['grains.filter_by']({'default': service_grains}, merge=grain_action_meta) %}
-#}
-{%- endif %}
-{%- endfor %}
+{%- do service_grains.get(service_grain_name).get(service_action_name).update(grain_action_meta) %}
 
 {%- endif %}
 {%- endfor %}
 
+{%- endif %}
+{%- endfor %}
 
 heka_{{ service_name }}_grain:
   file.managed:

--- a/heka/files/toml/output/influxdb.toml
+++ b/heka/files/toml/output/influxdb.toml
@@ -2,9 +2,11 @@
 type = "HttpOutput"
 message_matcher = "Fields[payload_type] == 'txt' && Fields[payload_name] == 'influxdb'"
 encoder = "influxdb_encoder"
-address = "http://{{ output.host }}:8086/write?db=lma&precision=ms"
-username = "influxdb"
-password = "influxdbpass"
+address = "http://{{ output.host }}:{{ output.port }}/write?db={{ output.database }}&precision=ms"
+{%- if output.username and output.password %}
+username = "{{ output.username }}"
+password = "{{ output.password }}"
+{%- endif %}
 http_timeout = 5000
 method = "POST"
 use_buffering = true

--- a/heka/meta/heka.yml
+++ b/heka/meta/heka.yml
@@ -68,6 +68,16 @@ metric_collector:
       module_dir: /usr/share/lma_collector/common;/usr/share/heka/lua_modules
       preserve_data: false
       message_matcher: "Type == 'heka.all-report'"
+    influxdb_accumulator:
+      engine: sandbox
+      module_file: /usr/share/lma_collector/filters/influxdb_accumulator.lua
+      module_dir: /usr/share/lma_collector/common;/usr/share/heka/lua_modules
+      preserve_data: false
+      message_matcher: "Fields[aggregator] == NIL && Type =~ /metric$/"
+      ticker_interval: 1
+      config:
+        tag_fields: "deployment_id environment_label tenant_id user_id"
+        time_precision: "ms"
   encoder:
     influxdb:
       engine: payload


### PR DESCRIPTION
This PR makes it possible to configure the metric collector to send metrics to InfluxDB. The InfluxDB output plugin is to be declared in the user metadata, just like it's done for the log collector and Elasticsearch. For this to work I had to change the Jinja2 code where the reclass metadata and the support metadata are merged together.

This is the user configuration I use in my reclass model:

``` yaml
parameters:
  heka:
    metric_collector:
      enabled: true
      output:
        influxdb:
          engine: influxdb
          host: ${_param:heka_influxdb_host}
          port: ${_param:influxdb_port}
          database: ${_param:influxdb_database}
          username: ${_param:influxdb_user}
          password: ${_param:influxdb_password}
```
