### PR TITLE
Make InfluxDB time precision configurable

### DIFF
--- a/heka/files/toml/output/influxdb.toml
+++ b/heka/files/toml/output/influxdb.toml
@@ -2,7 +2,7 @@
 type = "HttpOutput"
 message_matcher = "Fields[payload_type] == 'txt' && Fields[payload_name] == 'influxdb'"
 encoder = "influxdb_encoder"
-address = "http://{{ output.host }}:{{ output.port }}/write?db={{ output.database }}&precision=ms"
+address = "http://{{ output.host }}:{{ output.port }}/write?db={{ output.database }}&precision={{ output.time_precision }}"
 {%- if output.username and output.password %}
 username = "{{ output.username }}"
 password = "{{ output.password }}"

--- a/heka/map.jinja
+++ b/heka/map.jinja
@@ -16,6 +16,7 @@ Debian:
   decoder: {}
   extra_fields:
     environment_label: {{ grains.domain }}
+  influxdb_time_precision: ms
 RedHat:
   groups:
   - adm

--- a/heka/meta/heka.yml
+++ b/heka/meta/heka.yml
@@ -1,3 +1,5 @@
+{%- from "heka/map.jinja" import server with context %}
+
 log_collector:
   encoder:
     elasticsearch:
@@ -77,7 +79,7 @@ metric_collector:
       ticker_interval: 1
       config:
         tag_fields: "deployment_id environment_label tenant_id user_id"
-        time_precision: "ms"
+        time_precision: "{{ server.influxdb_time_precision }}"
   encoder:
     influxdb:
       engine: payload

--- a/metadata/service/metric_collector/single.yml
+++ b/metadata/service/metric_collector/single.yml
@@ -6,3 +6,4 @@ parameters:
   heka:
     metric_collector:
       enabled: true
+      influxdb_time_precision: ms


### PR DESCRIPTION
This is to address a comment from @simonpasquier in https://github.com/tcpcloud/salt-formula-heka/pull/13.

Please review.