### PR TITLE
Configure Elasticsearch output through Pillar

### DIFF
--- a/heka/files/toml/output/elasticsearch.toml
+++ b/heka/files/toml/output/elasticsearch.toml
@@ -1,10 +1,10 @@
 [{{ output_name }}_output]
 type = "ElasticSearchOutput"
-message_matcher = "{{ output.message_matcher }}"
-encoder = "{{ output.encoder }}"
+message_matcher = "Type == 'log' || Type == 'notification'"
+encoder = "elasticsearch_encoder"
 server = "http://{{ output.host }}:{{ output.port }}"
-flush_interval = {{ output.flush_interval }}
-flush_count = {{ output.flush_count }}
+flush_interval = 5000
+flush_count = 100
 use_buffering = true
 
 [{{ output_name }}_output.buffering]

--- a/heka/meta/heka.yml
+++ b/heka/meta/heka.yml
@@ -3,14 +3,6 @@ log_collector:
     elasticsearch:
       engine: elasticsearch
   output:
-    elasticsearch:
-      engine: elasticsearch
-      message_matcher: "Type == 'log' || Type  == 'notification'"
-      encoder: elasticsearch_encoder
-      host: mon
-      port: 9200
-      flush_interval: 5000
-      flush_count: 100
     metric_collector:
       engine: tcp
       host: 127.0.0.1


### PR DESCRIPTION
This is to be consistent with the way the InfluxDB output is configured. This is also to be able to set the Elasticsearch host in the user metadata. Up to now the Elasticsearch host was hardcoded to "mon" in the support metadata, which was obviously wrong.

See https://github.com/Mirantis/mk-lab-salt-model/pull/27 for the corresponding changes to the user model.