### PR TITLE
Use influxdb_time_precision for InfluxDB output

### DIFF
--- a/heka/files/toml/output/influxdb.toml
+++ b/heka/files/toml/output/influxdb.toml
@@ -1,8 +1,10 @@
+{%- from "heka/map.jinja" import server with context %}
+
 [{{ output_name }}_output]
 type = "HttpOutput"
 message_matcher = "Fields[payload_type] == 'txt' && Fields[payload_name] == 'influxdb'"
 encoder = "influxdb_encoder"
-address = "http://{{ output.host }}:{{ output.port }}/write?db={{ output.database }}&precision={{ output.time_precision }}"
+address = "http://{{ output.host }}:{{ output.port }}/write?db={{ output.database }}&precision={{ server.influxdb_time_precision }}"
 {%- if output.username and output.password %}
 username = "{{ output.username }}"
 password = "{{ output.password }}"


### PR DESCRIPTION
This uses `influxdb_time_precision` set on `metric_collector` for configuring the time precision in the InfluxDB output. This is to use just one parameter for both the InfluxDB accumulator filter and InfluxDB output.