### PR TITLE
Set tz in decoder sandbox config

### DIFF
--- a/heka/files/toml/decoder/sandbox.toml
+++ b/heka/files/toml/decoder/sandbox.toml
@@ -17,9 +17,10 @@ instruction_limit = "{{ decoder.instruction_limit }}"
 output_limit = "{{ decoder.output_limit }}"
 {%- endif %}
 
-{%- if decoder.config is defined %}
 [{{ decoder_name }}_decoder.config]
-{%- for config_param, config_value in decoder.config.iteritems() %}
+{%- for config_param, config_value in decoder.get('config', {}).iteritems() %}
 {{ config_param }} = {% if config_value is string %}"{{ config_value }}"{% elif config_value in [True, False] %}{{ config_value|lower }}{% else %}{{ config_value }}{% endif %}
 {%- endfor %}
+{%- if not "tz" in decoder.get('config', {}) and salt['pillar.get']('linux:system:timezone') %}
+tz = "{{ salt['pillar.get']('linux:system:timezone') }}"
 {%- endif %}


### PR DESCRIPTION
This commit sets `tz` in the config of decoder sandboxes if a specific timezone is set in `linux:system:timezone` in Pillar.

This provides an alternative to https://review.openstack.org/#/q/topic:openstack-log-timezone. 