### PR TITLE
Add generic timezone support to decoders

### DIFF
--- a/heka/files/toml/decoder/sandbox.toml
+++ b/heka/files/toml/decoder/sandbox.toml
@@ -1,3 +1,5 @@
+{%- from "heka/map.jinja" import server with context %}
+
 [{{ decoder_name }}_decoder]
 type = "SandboxDecoder"
 filename = "{{ decoder.module_file }}"
@@ -17,9 +19,12 @@ instruction_limit = "{{ decoder.instruction_limit }}"
 output_limit = "{{ decoder.output_limit }}"
 {%- endif %}
 
-{%- if decoder.config is defined %}
+{%- if decoder.config is defined or decoder.get('adjust_timezone', False) %}
 [{{ decoder_name }}_decoder.config]
-{%- for config_param, config_value in decoder.config.iteritems() %}
+{%- for config_param, config_value in decoder.get('config', {}).iteritems() %}
 {{ config_param }} = {% if config_value is string %}"{{ config_value }}"{% elif config_value in [True, False] %}{{ config_value|lower }}{% else %}{{ config_value }}{% endif %}
 {%- endfor %}
+{%- if decoder.get('adjust_timezone') and server.timezone is defined %}
+tz = "{{ server.timezone }}"
+{%- endif %}
 {%- endif %}

--- a/heka/map.jinja
+++ b/heka/map.jinja
@@ -17,6 +17,9 @@ Debian:
   extra_fields:
     environment_label: {{ grains.domain }}
   influxdb_time_precision: ms
+  {%- if pillar.get('linux', {}).get('system', {}).timezone is defined %}
+  timezone: "{{ pillar.linux.system.timezone }}"
+  {%- endif %}
 RedHat:
   groups:
   - adm


### PR DESCRIPTION
This change add a new parameter 'adjust_timezone' for the sandbox
decoder. This parameter should be set to true when the data to be
decoded doesn't contain the proper timezone information.