### PR TITLE
Disable the heka service completely

### DIFF
--- a/heka/_common.sls
+++ b/heka/_common.sls
@@ -31,9 +31,12 @@ heka_acl_log:
   - name: "setfacl -R -m g:adm:rx /var/log; setfacl -R -d -m g:adm:rx /var/log"
   - unless: "getfacl /var/log/|grep default:group:adm"
 
-heka_service:
-  service.dead:
-  - name: heka
+hekad_process:
+  process.absent:
+  - name: 'hekad -config=/etc/heka'
+
+/etc/init.d/heka:
+  file.absent
 
 heka_grains_dir:
   file.directory:


### PR DESCRIPTION
Without this patch `service heka status` reports that the heka service is running. For example:
```
root@ctl01:/etc/init.d# /etc/init.d/heka status
 * hekad is running
```