### PR TITLE
Fix bug in map.jinja

### DIFF
--- a/heka/map.jinja
+++ b/heka/map.jinja
@@ -30,28 +30,39 @@ RedHat:
 {%- endload %}
 {%- set server = salt['grains.filter_by'](server_defaults, merge=salt['pillar.get']('heka:server')) %}
 
-{%- load_yaml as elasticsearch_defaults %}
-default:
-  elasticsearch_port: 9200
-{%- endload %}
-{% set log_collector = salt['grains.filter_by'](elasticsearch_defaults, merge=salt['pillar.get']('heka:log_collector')) %}
+{% set default_elasticsearch_port = 9200 %}
+{% set default_influxdb_port = 8086 %}
+{% set default_influxdb_time_precision = 'ms' %}
+{% set default_influxdb_timeout = 5000 %}
+{% set default_aggregator_port = 5565 %}
 
-{%- load_yaml as influxdb_defaults %}
-default:
-  influxdb_port: 8086
-  influxdb_time_precision: ms
-  influxdb_timeout: 5000
-{%- endload %}
+{% set log_collector = salt['grains.filter_by']({
+  'default': {
+    'elasticsearch_port': default_elasticsearch_port,
+  }
+}, merge=salt['pillar.get']('heka:log_collector')) %}
 
-{%- load_yaml as metric_collector_defaults %}
-default:
-  aggregator_port: 5565
-{%- endload %}
-{% set metric_collector = salt['grains.filter_by'](
-    metric_collector_defaults,
-    merge=salt['grains.filter_by'](
-        influxdb_defaults,
-        merge=salt['pillar.get']('heka:metric_collector'))) %}
+{% set metric_collector = salt['grains.filter_by']({
+  'default': {
+    'influxdb_port': default_influxdb_port,
+    'influxdb_time_precision': default_influxdb_time_precision,
+    'influxdb_timeout': default_influxdb_timeout,
+    'aggregator_port': default_aggregator_port,
+  }
+}, merge=salt['pillar.get']('heka:metric_collector')) %}
 
-{% set remote_collector = salt['grains.filter_by'](influxdb_defaults, merge=salt['pillar.get']('heka:remote_collector')) %}
-{% set aggregator = salt['grains.filter_by'](influxdb_defaults, merge=salt['pillar.get']('heka:aggregator')) %}
+{% set remote_collector = salt['grains.filter_by']({
+  'default': {
+    'influxdb_port': default_influxdb_port,
+    'influxdb_time_precision': default_influxdb_time_precision,
+    'influxdb_timeout': default_influxdb_timeout,
+  }
+}, merge=salt['pillar.get']('heka:remote_collector')) %}
+
+{% set aggregator = salt['grains.filter_by']({
+  'default': {
+    'influxdb_port': default_influxdb_port,
+    'influxdb_time_precision': default_influxdb_time_precision,
+    'influxdb_timeout': default_influxdb_timeout,
+  }
+}, merge=salt['pillar.get']('heka:aggregator')) %}


### PR DESCRIPTION
Fix a bug in map.jinja where the filter_by for the metric_collector modified the influxdb_defaults dict re-used for the remote_collector. The filter_by function does deep merges, so some caution is required.