### PR TITLE
Activate aggregator output in remote collector

### DIFF
--- a/heka/map.jinja
+++ b/heka/map.jinja
@@ -56,6 +56,7 @@ RedHat:
     'influxdb_port': default_influxdb_port,
     'influxdb_time_precision': default_influxdb_time_precision,
     'influxdb_timeout': default_influxdb_timeout,
+    'aggregator_port': default_aggregator_port,
   }
 }, merge=salt['pillar.get']('heka:remote_collector')) %}
 

--- a/heka/meta/heka.yml
+++ b/heka/meta/heka.yml
@@ -184,6 +184,13 @@ remote_collector:
       encoder: influxdb_encoder
       timeout: {{ remote_collector.influxdb_timeout }}
 {%- endif %}
+{%- if remote_collector.aggregator_host is defined %}
+    aggregator:
+      engine: tcp
+      host: "{{ remote_collector.aggregator_host }}"
+      port: "{{ remote_collector.aggregator_port }}"
+      message_matcher: "Fields[aggregator] == NIL && Type == 'heka.sandbox.afd_metric'"
+{%- endif %}
 aggregator:
   policy:
     # A policy defining that the cluster's status depends on the member with

--- a/heka/meta/heka.yml
+++ b/heka/meta/heka.yml
@@ -153,7 +153,7 @@ remote_collector:
       module_file: /usr/share/lma_collector/filters/influxdb_accumulator.lua
       module_dir: /usr/share/lma_collector/common;/usr/share/heka/lua_modules
       preserve_data: false
-      message_matcher: "Type =~ /metric$/"
+      message_matcher: "Type == 'heka.sandbox.afd_metric'"
       ticker_interval: 1
       config:
         tag_fields: "deployment_id environment_label tenant_id user_id"


### PR DESCRIPTION
This PR activates the aggregator output in the remote collector

It also changes the influxdb accumulator filter to only match afd metrics. We currently don't have a "remote collectd" instance on the monitoring node(s), so this change avoids sending metrics twice to InfluxDB.