### PR TITLE
Set consistent and predictive hostname.

### DIFF
--- a/heka/files/toml/global.toml
+++ b/heka/files/toml/global.toml
@@ -4,7 +4,7 @@
 maxprocs={{ workers }}
 base_dir="/var/cache/{{ service_name }}"
 
-hostname="{{ grains.fqdn.split('.')[0] }}"
+hostname="{{ pillar.get('linux',{}).get('system',{}).name|default(grains.host) }}"
 
 max_message_size = 262144
 max_process_inject = 1

--- a/heka/meta/heka.yml
+++ b/heka/meta/heka.yml
@@ -12,7 +12,7 @@ log_collector:
       message_matcher: "Type == 'log' && Fields[http_response_time] != NIL"
       ticker_interval: 10
       config:
-        hostname: '{{ grains.host }}'
+        hostname: '{{ pillar.get('linux',{}).get('system',{}).name|default(grains.host) }}'
         interval: 10
         max_timer_inject: 10
         bulk_size: 523
@@ -26,7 +26,7 @@ log_collector:
       message_matcher: "Type == 'log' && Logger =~ /^openstack\\\\./"
       ticker_interval: 1
       config:
-        hostname: '{{ grains.host }}'
+        hostname: '{{ pillar.get('linux',{}).get('system',{}).name|default(grains.host) }}'
         interval: 60
         grace_interval: 30
 {%- if log_collector.elasticsearch_host is defined %}
@@ -59,7 +59,7 @@ metric_collector:
       module_file: /usr/share/lma_collector/decoders/collectd.lua
       module_dir: /usr/share/lma_collector/common;/usr/share/heka/lua_modules
       config:
-        hostname: '{{ grains.fqdn.split('.')[0] }}'
+        hostname: '{{ pillar.get('linux',{}).get('system',{}).name|default(grains.host) }}'
         swap_size: 4294967296
     metric:
       engine: sandbox
@@ -138,7 +138,7 @@ remote_collector:
       module_file: /usr/share/lma_collector/decoders/collectd.lua
       module_dir: /usr/share/lma_collector/common;/usr/share/heka/lua_modules
       config:
-        hostname: '{{ grains.host }}'
+        hostname: '{{ pillar.get('linux',{}).get('system',{}).name|default(grains.host) }}'
   input:
     heka_collectd:
       engine: http


### PR DESCRIPTION
The monitoring node get 'mon' as hostname  when using 'host' grains while it
should be 'mon01'.

The collectd formula already uses the linux.system.name pillar which
seems to be the good option.