### PR TITLE
Send only alarm-related data to mine

### DIFF
--- a/_modules/heka_alarming.py
+++ b/_modules/heka_alarming.py
@@ -73,3 +73,24 @@ def dimensions(alarm_or_alarm_cluster):
             raise Exception(
                 'Dimension value {} includes disallowed chars'.format(value))
     return dimensions
+
+
+def grains_for_mine(grains):
+    """
+    Return grains that need to be sent to Salt Mine. Only the alarm
+    and alarm cluster data is to be sent to Mine.
+    """
+    filtered_grains = {}
+    for service_name, service_data in grains.items():
+        alarm = service_data.get('alarm')
+        if alarm:
+            filtered_grains[service_name] = {'alarm': alarm}
+        alarm_cluster = service_data.get('alarm_cluster')
+        if alarm_cluster:
+            if service_name in filtered_grains:
+                filtered_grains[service_name].update(
+                    {'alarm_cluster': alarm_cluster})
+            else:
+                filtered_grains[service_name] = \
+                    {'alarm_cluster': alarm_cluster}
+    return filtered_grains

--- a/heka/_service.sls
+++ b/heka/_service.sls
@@ -179,7 +179,7 @@ heka_{{ service_name }}_grain:
   - mode: 600
   - defaults:
     service_grains:
-      heka: {{ service_grains|yaml }}
+      heka: {{ salt['heka_alarming.grains_for_mine'](service_grains)|yaml }}
   - require:
     - file: heka_grains_dir
 


### PR DESCRIPTION
We currently have a bug where the remote_collector has the following collectd decoder configuration (`decoder_collectd.toml`):

```toml
[collectd_decoder]
type = "SandboxDecoder"
filename = "/usr/share/lma_collector/decoders/collectd.lua"
module_directory = "/usr/share/lma_collector/common;/usr/share/heka/lua_modules"
[collectd_decoder.config]
hostname = "ctl02"
```

The "hostname" is set to "ctl02" while it should be set to "mon01". The issue is related to the Heka meta data we store in Salt Mine.

This patch fixes the problem by selecting the data we store in Salt Mine. Only the alarm-related data is stored. This also minimizes the amount of data we write it, and read from, Salt Mine.