### PR TITLE
Configure Hekad poolsize by pillar data

### DIFF
--- a/heka/_service.sls
+++ b/heka/_service.sls
@@ -1,8 +1,6 @@
 {%- macro load_grains_file(grains_fragment_file) %}{% include grains_fragment_file ignore missing %}{% endmacro %}
 
-{%- set server = salt['pillar.get']('heka:'+service_name) %}
-
-{%- if server.enabled %}
+{%- if server.enabled is defined and server.enabled %}
 
 heka_{{ service_name }}_log_file:
   file.managed:
@@ -191,6 +189,7 @@ heka_{{ service_name }}_grain:
   - group: heka
   - defaults:
     service_name: {{ service_name }}
+    poolsize: {{ server.poolsize }}
   - require:
     - file: heka_{{ service_name }}_conf_dir
   - require_in:

--- a/heka/aggregator.sls
+++ b/heka/aggregator.sls
@@ -3,6 +3,8 @@
 include:
 - heka._common
 
+{%- from "heka/map.jinja" import aggregator with context %}
+{%- set server = aggregator %}
 {%- set service_name = "aggregator" %}
 
 {%- include "heka/_service.sls" %}

--- a/heka/files/toml/global.toml
+++ b/heka/files/toml/global.toml
@@ -9,4 +9,4 @@ hostname="{{ grains.fqdn.split('.')[0] }}"
 max_message_size = 262144
 max_process_inject = 1
 max_timer_inject = 10
-poolsize = 100
+poolsize = {{ poolsize }}

--- a/heka/log_collector.sls
+++ b/heka/log_collector.sls
@@ -3,6 +3,8 @@
 include:
 - heka._common
 
+{%- from "heka/map.jinja" import log_collector with context %}
+{%- set server = log_collector %}
 {%- set service_name = "log_collector" %}
 
 {%- include "heka/_service.sls" %}

--- a/heka/map.jinja
+++ b/heka/map.jinja
@@ -41,6 +41,7 @@ RedHat:
 {% set log_collector = salt['grains.filter_by']({
   'default': {
     'elasticsearch_port': default_elasticsearch_port,
+    'poolsize': 100,
   }
 }, merge=salt['pillar.get']('heka:log_collector')) %}
 
@@ -51,6 +52,7 @@ RedHat:
     'influxdb_timeout': default_influxdb_timeout,
     'aggregator_port': default_aggregator_port,
     'nagios_port': default_nagios_port,
+    'poolsize': 100,
   }
 }, merge=salt['pillar.get']('heka:metric_collector')) %}
 
@@ -60,6 +62,7 @@ RedHat:
     'influxdb_time_precision': default_influxdb_time_precision,
     'influxdb_timeout': default_influxdb_timeout,
     'aggregator_port': default_aggregator_port,
+    'poolsize': 100,
   }
 }, merge=salt['pillar.get']('heka:remote_collector')) %}
 
@@ -70,5 +73,6 @@ RedHat:
     'influxdb_timeout': default_influxdb_timeout,
     'nagios_port': default_nagios_port,
     'nagios_host_alarm_clusters': default_nagios_host_alarm_clusters,
+    'poolsize': 100,
   }
 }, merge=salt['pillar.get']('heka:aggregator')) %}

--- a/heka/metric_collector.sls
+++ b/heka/metric_collector.sls
@@ -3,6 +3,8 @@
 include:
 - heka._common
 
+{%- from "heka/map.jinja" import metric_collector with context %}
+{%- set server = metric_collector %}
 {%- set service_name = "metric_collector" %}
 
 {%- include "heka/_service.sls" %}

--- a/heka/remote_collector.sls
+++ b/heka/remote_collector.sls
@@ -3,6 +3,8 @@
 include:
 - heka._common
 
+{%- from "heka/map.jinja" import remote_collector with context %}
+{%- set server = remote_collector %}
 {%- set service_name = "remote_collector" %}
 
 {%- include "heka/_service.sls" %}

--- a/metadata/service/aggregator/single.yml
+++ b/metadata/service/aggregator/single.yml
@@ -3,7 +3,10 @@ applications:
 classes:
 - service.heka.support
 parameters:
+  _param:
+    aggregator_poolsize: 100
   heka:
     aggregator:
       enabled: true
       influxdb_time_precision: ms
+      poolsize: ${_param:aggregator_poolsize}

--- a/metadata/service/log_collector/single.yml
+++ b/metadata/service/log_collector/single.yml
@@ -3,6 +3,9 @@ applications:
 classes:
 - service.heka.support
 parameters:
+  _param:
+    log_collector_poolsize: 100
   heka:
     log_collector:
       enabled: true
+      poolsize: ${_param:log_collector_poolsize}

--- a/metadata/service/metric_collector/single.yml
+++ b/metadata/service/metric_collector/single.yml
@@ -3,7 +3,10 @@ applications:
 classes:
 - service.heka.support
 parameters:
+  _param:
+    metric_collector_poolsize: 100
   heka:
     metric_collector:
       enabled: true
       influxdb_time_precision: ms
+      poolsize: ${_param:metric_collector_poolsize}

--- a/metadata/service/remote_collector/single.yml
+++ b/metadata/service/remote_collector/single.yml
@@ -3,7 +3,10 @@ applications:
 classes:
 - service.heka.support
 parameters:
+  _param:
+    remote_collector_poolsize: 100
   heka:
     remote_collector:
       enabled: true
       influxdb_time_precision: ms
+      poolsize: ${_param:remote_collector_poolsize}


### PR DESCRIPTION
The poolsize must be increased depending on the number of filters.
Typically, the metric_collector on controller nodes and the aggregator on
monitoring node(s) should probably use poolsize=200.