### PR TITLE
Add missing hostname variable in GSE code

### DIFF
--- a/heka/files/lua/filters/gse_cluster_filter.lua
+++ b/heka/files/lua/filters/gse_cluster_filter.lua
@@ -64,6 +64,10 @@ function process_message()
         return -1, "Cannot find alarms in the AFD/GSE message"
     end
 
+    -- "hostname" is nil here when the input message is a GSE message, so nil
+    -- is not an error condition here
+    local hostname = afd.get_entity_name('hostname')
+
     local cluster_ids = gse.find_cluster_memberships(member_id)
 
     -- update all clusters that depend on this entity


### PR DESCRIPTION
https://github.com/tcpcloud/salt-formula-heka/pull/31/commits/7c4801d5172422896db801874637d902665dfd5c removed the setting of the `hostname` variable, which was a mistake.