### PR TITLE
Update collectd decoder for disk metrics

### DIFF
--- a/heka/files/lua/decoders/collectd.lua
+++ b/heka/files/lua/decoders/collectd.lua
@@ -148,7 +148,11 @@ function process_message ()
                 msg['Fields']['fs'] = mount
                 table.insert(msg['Fields']['tag_fields'], 'fs')
             elseif metric_source == 'disk' then
-                msg['Fields']['name'] = metric_name
+                if sample['type'] == 'disk_io_time' then
+                    msg['Fields']['name'] = 'disk' .. sep .. sample['dsnames'][i]
+                else
+                    msg['Fields']['name'] = metric_name
+                end
                 msg['Fields']['device'] = sample['plugin_instance']
                 table.insert(msg['Fields']['tag_fields'], 'device')
             elseif metric_source == 'cpu' then


### PR DESCRIPTION
The disk plugin shipping with the 5.5. version of collectd (installed on
Xenial) provides new metrics: disk_io_time and disk_weighted_io_time.