### PR TITLE
Set actual swap_size in collectd decoder

### DIFF
--- a/heka/meta/heka.yml
+++ b/heka/meta/heka.yml
@@ -60,7 +60,7 @@ metric_collector:
       module_dir: /usr/share/lma_collector/common;/usr/share/heka/lua_modules
       config:
         hostname: '{{ grains.fqdn.split('.')[0] }}'
-        swap_size: 4294967296
+        swap_size: {{ salt['ps.swap_memory']()['total'] }}
     metric:
       engine: sandbox
       module_file: /usr/share/lma_collector/decoders/metric.lua


### PR DESCRIPTION
Salt does not create Swap-related grains, but the "ps" module has a "swap_memory" function that can be used to get Swap data. This commit uses that function to set swap_size in the collectd decoder.