### PR TITLE
Send annotations to InfluxDB

### DIFF
--- a/heka/meta/heka.yml
+++ b/heka/meta/heka.yml
@@ -377,11 +377,17 @@ aggregator:
       module_file: /usr/share/lma_collector/filters/influxdb_accumulator.lua
       module_dir: /usr/share/lma_collector/common;/usr/share/heka/lua_modules
       preserve_data: false
-      message_matcher: "Type == 'heka.sandbox.gse_metric'"
+      message_matcher: "Type == 'heka.sandbox.gse_metric' || Type == 'heka.sandbox.metric'"
       ticker_interval: 1
       config:
         tag_fields: "deployment_id environment_label tenant_id user_id"
         time_precision: "{{ aggregator.influxdb_time_precision }}"
+    influxdb_annotation:
+      engine: sandbox
+      module_file: /usr/share/lma_collector/filters/influxdb_annotation.lua
+      module_dir: /usr/share/lma_collector/common;/usr/share/heka/lua_modules
+      preserve_data: false
+      message_matcher: "Type == 'heka.sandbox.gse_metric'"
 {%- endif %}
   encoder:
 {%- if aggregator.influxdb_host is defined %}


### PR DESCRIPTION
This changes the configuration of the aggregator to send annotations to InfluxDB. This is obviously necessary to be able to display annotations in the Grafana dashboards.