### PR TITLE
Add filter to compute resource creation timings

### DIFF
--- a/heka/files/lua/filters/resource_creation_time.lua
+++ b/heka/files/lua/filters/resource_creation_time.lua
@@ -30,7 +30,7 @@ local event_type_to_name = {
 function process_message ()
     local metric_name = event_type_to_name[read_message("Fields[event_type]")]
     if not metric_name then
-        return -1
+        return 0
     end
 
     local started_at, completed_at

--- a/heka/meta/heka.yml
+++ b/heka/meta/heka.yml
@@ -196,8 +196,9 @@ remote_collector:
       decoder: notification_decoder
 {%- endfor %}
 {%- endif %}
-{%- if remote_collector.influxdb_host is defined %}
+{%- if remote_collector.influxdb_host is defined or remote_collector.amqp_host is defined %}
   filter:
+{%- if remote_collector.influxdb_host is defined %}
     influxdb_accumulator:
       engine: sandbox
       module_file: /usr/share/lma_collector/filters/influxdb_accumulator.lua
@@ -208,6 +209,14 @@ remote_collector:
       config:
         tag_fields: "deployment_id environment_label tenant_id user_id"
         time_precision: "{{ remote_collector.influxdb_time_precision }}"
+{%- endif %}
+{%- if remote_collector.amqp_host is defined %}
+    resource_creation_time:
+      engine: sandbox
+      module_file: /usr/share/lma_collector/filters/resource_creation_time.lua
+      module_dir: /usr/share/lma_collector/common;/usr/share/heka/lua_modules
+      preserve_data: false
+      message_matcher: "Type == 'notification' && Fields[event_type] =~ /create.end$/"
 {%- endif %}
 {%- if remote_collector.influxdb_host is defined or remote_collector.elasticsearch_host is defined %}
   encoder:


### PR DESCRIPTION
This filter uses the OpenStack notifications to compute additional
metrics like the volume creation time (for Cinder) and the instance
creation time (for Nova).