### PR TITLE
Restart Heka services when Lua lib have changed

### DIFF
--- a/heka/_service.sls
+++ b/heka/_service.sls
@@ -70,6 +70,7 @@ heka_{{ service_name }}_service:
   service.running:
   - enable: True
   - watch:
+    - file: /usr/share/lma_collector
     - file: /usr/share/lma_collector/*
     - file: /etc/{{ service_name }}/*
 {%- else %}


### PR DESCRIPTION
The glob pattern doesn't work with file.recurse.
This is a regression introduced by 5c3e9136743816100f52ec7b9c099bf939653300