### PR TITLE
Take rule value field into account

### DIFF
--- a/heka/files/lma_alarm.lua
+++ b/heka/files/lma_alarm.lua
@@ -35,6 +35,9 @@ local alarms = {
             {%- endfor %}
           },
           {%- endif %}
+          {%- if _rule.value is defined %}
+          ['value'] = '{{ _rule.value }}',
+          {%- endif %}
         },
         {%- endfor %}
       },


### PR DESCRIPTION
An alarm rule may include a field "value" specifying the name of the value field to use. That field was not taken into account.