### PR TITLE
Make metric_collector output configurable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,8 @@ Log collector service
         elasticsearch_host: 172.16.10.253
         elasticsearch_port: 9200
         enabled: true
+        metric_collector_host: 127.0.0.1
+        metric_collector_port: 5567
         poolsize: 100
 
 Default values:
@@ -25,6 +27,8 @@ Default values:
 * ``automatic_starting: true``
 * ``elastisearch_port: 9200``
 * ``enabled: false``
+* ``metric_collector_host: 127.0.0.1``
+* ``metric_collector_port: 5567``
 * ``poolsize: 100``
 
 Local Metric collector service

--- a/heka/map.jinja
+++ b/heka/map.jinja
@@ -48,6 +48,8 @@ RedHat:
     'elasticsearch_port': default_elasticsearch_port,
     'poolsize': 100,
     'automatic_starting': default_automatic_starting,
+    'metric_collector_host': '127.0.0.1',
+    'metric_collector_port': 5567,
   }
 }, merge=salt['pillar.get']('heka:log_collector')) %}
 

--- a/heka/meta/heka.yml
+++ b/heka/meta/heka.yml
@@ -39,8 +39,8 @@ log_collector:
   output:
     metric_collector:
       engine: tcp
-      host: 127.0.0.1
-      port: 5567
+      host: {{ log_collector.metric_collector_host }}
+      port: {{ log_collector.metric_collector_port }}
       message_matcher: "(Type == 'metric' || Type == 'heka.sandbox.metric' || Type == 'heka.sandbox.bulk_metric')"
     log_dashboard:
       engine: dashboard


### PR DESCRIPTION
This commit makes the "metric_collector" output of the log_collector configurable, for consistency with the other outputs.