### PR TITLE
Avoid groups initialization  if required params aren't defined

### DIFF
--- a/_modules/heka_alarming.py
+++ b/_modules/heka_alarming.py
@@ -83,6 +83,8 @@ def grains_for_mine(grains):
     """
     filtered_grains = {}
     for service_name, service_data in grains.items():
+        if not service_data:
+            continue
         alarm = service_data.get('alarm')
         if alarm:
             filtered_grains[service_name] = {'alarm': alarm}

--- a/heka/meta/heka.yml
+++ b/heka/meta/heka.yml
@@ -471,8 +471,8 @@ aggregator:
   {%- endif %}
 {%- endif %}
 ceilometer_collector:
-  decoder:
 {%- if ceilometer_collector.amqp_host is defined %}
+  decoder:
     sample:
       engine: sandbox
       module_file: /usr/share/lma_collector/decoders/metering.lua
@@ -482,8 +482,8 @@ ceilometer_collector:
         decode_resources: {{ ceilometer_collector.resource_decoding|lower }}
         metadata_fields: "status deleted container_format min_ram updated_at min_disk is_public size checksum created_at disk_format protected instance_host host display_name instance_id instance_type status state user_metadata.stack"
 {%- endif %}
-  input:
 {%- if ceilometer_collector.amqp_host is defined %}
+  input:
     openstack_sample_amqp:
       engine: amqp
       user: {{ ceilometer_collector.amqp_user }}
@@ -500,8 +500,8 @@ ceilometer_collector:
       exchange_auto_delete: false
       queue_auto_delete: false
 {%- endif %}
-  filter:
 {%- if ceilometer_collector.influxdb_host is defined %}
+  filter:
     ceilometer_influxdb_accumulator:
       engine: sandbox
       module_file: /usr/share/lma_collector/filters/influxdb_accumulator.lua
@@ -515,14 +515,15 @@ ceilometer_collector:
         flush_count: 500
         bulk_metric_type_matcher: 'ceilometer_samples'
 {%- endif %}
+{%- if ceilometer_collector.influxdb_host is defined or ceilometer_collector.elasticsearch_host is defined %}
   encoder:
-{%- if ceilometer_collector.influxdb_host is defined %}
+  {%- if ceilometer_collector.influxdb_host is defined %}
     influxdb:
       engine: payload
       append_newlines: false
       prefix_ts: false
-{%- endif %}
-{%- if ceilometer_collector.elasticsearch_host is defined %}
+  {%- endif %}
+  {%- if ceilometer_collector.elasticsearch_host is defined %}
     elasticsearch_resource:
       engine: sandbox
       module_file:  /usr/share/lma_collector/encoders/es_ceilometer_resources.lua
@@ -531,6 +532,7 @@ ceilometer_collector:
         index: "ceilometer_resource"
         type_name: "source"
         encoder: "elasticsearch_resources"
+  {%- endif %}
 {%- endif %}
 {%- if ceilometer_collector.influxdb_host is defined or ceilometer_collector.elasticsearch_host is defined %}
   output:

--- a/heka/meta/heka.yml
+++ b/heka/meta/heka.yml
@@ -77,8 +77,8 @@ metric_collector:
       port: 5567
       decoder: metric_decoder
       splitter: HekaFramingSplitter
-  filter:
 {%- if metric_collector.influxdb_host is defined %}
+  filter:
     influxdb_accumulator:
       engine: sandbox
       module_file: /usr/share/lma_collector/filters/influxdb_accumulator.lua
@@ -90,21 +90,24 @@ metric_collector:
         tag_fields: "deployment_id environment_label tenant_id user_id"
         time_precision: "{{ metric_collector.influxdb_time_precision }}"
 {%- endif %}
-{%- if metric_collector.influxdb_host is defined %}
+{%- if metric_collector.influxdb_host is defined or metric_collector.nagios_host is defined %}
   encoder:
+  {%- if metric_collector.influxdb_host is defined %}
     influxdb:
       engine: payload
       append_newlines: false
       prefix_ts: false
-{%- endif %}
-{%- if metric_collector.nagios_host is defined %}
+  {%- endif %}
+  {%- if metric_collector.nagios_host is defined %}
     nagios:
       engine: sandbox
       module_file: /usr/share/lma_collector/encoders/status_nagios.lua
       module_dir: /usr/share/lma_collector/common;/usr/share/heka/lua_modules
+  {%- endif %}
 {%- endif %}
+{%- if metric_collector.influxdb_host is defined or metric_collector.aggregator_host is defined or metric_collector.nagios_host is defined %}
   output:
-{%- if metric_collector.influxdb_host is defined %}
+  {%- if metric_collector.influxdb_host is defined %}
     influxdb:
       engine: http
       address: "http://{{ metric_collector.influxdb_host }}:{{ metric_collector.influxdb_port }}/write?db={{ metric_collector.influxdb_database }}&precision={{ metric_collector.influxdb_time_precision }}"
@@ -115,15 +118,15 @@ metric_collector:
       message_matcher: "Fields[payload_type] == 'txt' && Fields[payload_name] == 'influxdb'"
       encoder: influxdb_encoder
       timeout: {{ metric_collector.influxdb_timeout }}
-{%- endif %}
-{%- if metric_collector.aggregator_host is defined %}
+  {%- endif %}
+  {%- if metric_collector.aggregator_host is defined %}
     aggregator:
       engine: tcp
       host: "{{ metric_collector.aggregator_host }}"
       port: "{{ metric_collector.aggregator_port }}"
       message_matcher: "Type == 'heka.sandbox.afd_metric'"
-{%- endif %}
-{%- if metric_collector.nagios_host is defined %}
+  {%- endif %}
+  {%- if metric_collector.nagios_host is defined %}
     nagios_alarm:
       engine: http
       address: "http://{{ metric_collector.nagios_host }}:{{metric_collector.nagios_port }}/status"
@@ -136,6 +139,7 @@ metric_collector:
       max_buffer_size: 1048576
       max_file_size: 524288
       full_action: drop
+  {%- endif %}
 {%- endif %}
 remote_collector:
   decoder:
@@ -182,7 +186,7 @@ remote_collector:
 {%- endif %}
 {%- if remote_collector.influxdb_host is defined or remote_collector.amqp_host is defined %}
   filter:
-{%- if remote_collector.influxdb_host is defined %}
+  {%- if remote_collector.influxdb_host is defined %}
     influxdb_accumulator:
       engine: sandbox
       module_file: /usr/share/lma_collector/filters/influxdb_accumulator.lua
@@ -193,31 +197,32 @@ remote_collector:
       config:
         tag_fields: "deployment_id environment_label tenant_id user_id"
         time_precision: "{{ remote_collector.influxdb_time_precision }}"
-{%- endif %}
-{%- if remote_collector.amqp_host is defined %}
+  {%- endif %}
+  {%- if remote_collector.amqp_host is defined %}
     resource_creation_time:
       engine: sandbox
       module_file: /usr/share/lma_collector/filters/resource_creation_time.lua
       module_dir: /usr/share/lma_collector/common;/usr/share/heka/lua_modules
       preserve_data: false
       message_matcher: "Type == 'notification' && Fields[event_type] =~ /create.end$/"
-{%- endif %}
+  {%- endif %}
 {%- endif %}
 {%- if remote_collector.influxdb_host is defined or remote_collector.elasticsearch_host is defined %}
   encoder:
-{%- if remote_collector.influxdb_host is defined %}
+  {%- if remote_collector.influxdb_host is defined %}
     influxdb:
       engine: payload
       append_newlines: false
       prefix_ts: false
-{%- endif %}
-{%- if remote_collector.elasticsearch_host is defined %}
+  {%- endif %}
+  {%- if remote_collector.elasticsearch_host is defined %}
     elasticsearch:
       engine: elasticsearch
+  {%- endif %}
 {%- endif %}
-{%- endif %}
+{%- if remote_collector.influxdb_host is defined or remote_collector.aggregator_host is defined or remote_collector.elasticsearch_host is defined %}
   output:
-{%- if remote_collector.influxdb_host is defined %}
+  {%- if remote_collector.influxdb_host is defined %}
     influxdb:
       engine: http
       address: "http://{{ remote_collector.influxdb_host }}:{{ remote_collector.influxdb_port }}/write?db={{ remote_collector.influxdb_database }}&precision={{ remote_collector.influxdb_time_precision }}"
@@ -228,20 +233,21 @@ remote_collector:
       message_matcher: "Fields[payload_type] == 'txt' && Fields[payload_name] == 'influxdb'"
       encoder: influxdb_encoder
       timeout: {{ remote_collector.influxdb_timeout }}
-{%- endif %}
-{%- if remote_collector.aggregator_host is defined %}
+  {%- endif %}
+  {%- if remote_collector.aggregator_host is defined %}
     aggregator:
       engine: tcp
       host: "{{ remote_collector.aggregator_host }}"
       port: "{{ remote_collector.aggregator_port }}"
       message_matcher: "Type == 'heka.sandbox.afd_metric'"
-{%- endif %}
-{%- if remote_collector.elasticsearch_host is defined %}
+  {%- endif %}
+  {%- if remote_collector.elasticsearch_host is defined %}
     elasticsearch:
       engine: elasticsearch
       server: "http://{{ remote_collector.elasticsearch_host }}:{{ remote_collector.elasticsearch_port }}"
       encoder: elasticsearch_encoder
       message_matcher: "Type == 'notification'"
+  {%- endif %}
 {%- endif %}
 aggregator:
   policy:
@@ -415,14 +421,15 @@ aggregator:
       preserve_data: false
       message_matcher: "Type == 'heka.sandbox.gse_metric'"
 {%- endif %}
+{%- if aggregator.influxdb_host is defined or aggregator.nagios_host is defined %}
   encoder:
-{%- if aggregator.influxdb_host is defined %}
+  {%- if aggregator.influxdb_host is defined %}
     influxdb:
       engine: payload
       append_newlines: false
       prefix_ts: false
-{%- endif %}
-{%- if aggregator.nagios_host is defined %}
+  {%- endif %}
+  {%- if aggregator.nagios_host is defined %}
     nagios:
       engine: sandbox
       module_file: /usr/share/lma_collector/encoders/status_nagios.lua
@@ -432,9 +439,11 @@ aggregator:
         {%- if aggregator.nagios_host_dimension_key is defined %}
         nagios_host_dimension_key: "{{ aggregator.nagios_host_dimension_key }}"
         {%- endif %}
+  {%- endif %}
 {%- endif %}
+{%- if aggregator.influxdb_host is defined or aggregator.nagios_host is defined %}
   output:
-{%- if aggregator.influxdb_host is defined %}
+  {%- if aggregator.influxdb_host is defined %}
     influxdb:
       engine: http
       address: "http://{{ aggregator.influxdb_host }}:{{ aggregator.influxdb_port }}/write?db={{ aggregator.influxdb_database }}&precision={{ aggregator.influxdb_time_precision }}"
@@ -445,8 +454,8 @@ aggregator:
       message_matcher: "Fields[payload_type] == 'txt' && Fields[payload_name] == 'influxdb'"
       encoder: influxdb_encoder
       timeout: {{ aggregator.influxdb_timeout }}
-{%- endif %}
-{%- if aggregator.nagios_host is defined %}
+  {%- endif %}
+  {%- if aggregator.nagios_host is defined %}
     nagios_alarm_cluster:
       engine: http
       address: "http://{{ aggregator.nagios_host }}:{{aggregator.nagios_port }}/status"
@@ -459,6 +468,7 @@ aggregator:
       max_buffer_size: 1048576
       max_file_size: 524288
       full_action: drop
+  {%- endif %}
 {%- endif %}
 ceilometer_collector:
   decoder:


### PR DESCRIPTION
In ceilometer collector we don't need a initialization of decoder,
encoder, input and output if amqp, influxdb or elasticsearch connections
are not defined.