### PR TITLE
Set log_collector poolsize to 200

### DIFF
--- a/metadata/service/log_collector/single.yml
+++ b/metadata/service/log_collector/single.yml
@@ -4,7 +4,7 @@ classes:
 - service.heka.support
 parameters:
   _param:
-    log_collector_poolsize: 100
+    log_collector_poolsize: 200
   heka:
     log_collector:
       enabled: true


### PR DESCRIPTION
This commit changes the log_collector's `poolsize` from 100 to 200 in the `service.log_collector.single` class.

With a poolsize of 100 we've seen cases where the Heka pipeline reaches unrecoverable deadlock situations. We've reproduced these situations by forcing Heka to process a large quantities of logs. We haven't been able to reproduce the problem with a poolsize of 200.

The downside of using a larger pool is the memory consumption of the hekad process. With a poolsize of 100 the RSS of hekad is 164 MB right after startup, while it is 210 MB with a poolsize of 200.