### PR TITLE
Fix issue with missed endif

### DIFF
--- a/heka/meta/heka.yml
+++ b/heka/meta/heka.yml
@@ -105,6 +105,7 @@ metric_collector:
       module_dir: /usr/share/lma_collector/common;/usr/share/heka/lua_modules
       config:
         host_suffix_dimension_key: environment_label
+   {%- endif %}
 {%- endif %}
 {%- if metric_collector.influxdb_host is defined or metric_collector.aggregator_host is defined or metric_collector.nagios_host is defined %}
   output:


### PR DESCRIPTION
@elemoine, @simonpasquier, @cznewt 

endif for expression on line 93 has been deleted in https://github.com/tcpcloud/salt-formula-heka/commit/a7cf2d5214185873e54b036bbc4db10e8f935b87. 

This PR fix it