### PR TITLE
[ceilometer-collector] Continue resource injecting after samples failure

### DIFF
--- a/heka/files/lua/common/ceilometer.lua
+++ b/heka/files/lua/common/ceilometer.lua
@@ -51,7 +51,7 @@ end
 
 function decode(data)
     local code, msg = inject(samples_decoder:decode(data))
-    if code == 0 and resource_decoder then
+    if resource_decoder then
         code, msg = inject(resource_decoder:decode(data))
     end
     return code, msg

--- a/heka/files/lua/common/resources.lua
+++ b/heka/files/lua/common/resources.lua
@@ -100,11 +100,11 @@ end
 function ResourcesDecoder:decode (data)
     local ok, message = pcall(cjson.decode, data)
     if not ok then
-        return -2, "Cannot decode Payload"
+        return -1, "Cannot decode Payload"
     end
     local ok, message_body = pcall(cjson.decode, message["oslo.message"])
     if not ok then
-        return -2, "Cannot decode Payload[oslo.message]"
+        return -1, "Cannot decode Payload[oslo.message]"
     end
     local resource_payload = {}
     if message_body['payload'] then
@@ -115,7 +115,7 @@ function ResourcesDecoder:decode (data)
         resource_msg.Timestamp = patt.Timestamp:match(message_body.timestamp)
         return 0, resource_msg
     end
-    return -2, "Empty message"
+    return -1, "Empty message"
 end
 
 return ResourcesDecoder

--- a/heka/files/lua/common/samples.lua
+++ b/heka/files/lua/common/samples.lua
@@ -173,11 +173,11 @@ end
 function SamplesDecoder:decode (data)
     local ok, message = pcall(cjson.decode, data)
     if not ok then
-        return -2, "Cannot decode Payload"
+        return -1, "Cannot decode Payload"
     end
     local ok, message_body = pcall(cjson.decode, message["oslo.message"])
     if not ok then
-        return -2, "Cannot decode Payload[oslo.message]"
+        return -1, "Cannot decode Payload[oslo.message]"
     end
     local sample_payload = {}
     if message_body['payload'] then
@@ -188,7 +188,7 @@ function SamplesDecoder:decode (data)
         sample_msg.Timestamp = patt.Timestamp:match(message_body.timestamp)
         return 0, sample_msg
     end
-    return -2, "Empty message"
+    return -1, "Empty message"
 end
 
 return SamplesDecoder


### PR DESCRIPTION
This change is need because we should save resources even
if samples data is corrupted.
Also, -2 exit codes changed to -1, because -2 is used
for encoders only