### PR TITLE
Adding support for sensu as alerting destination

### DIFF
--- a/heka/files/lua/encoders/status_sensu.lua
+++ b/heka/files/lua/encoders/status_sensu.lua
@@ -1,0 +1,92 @@
+-- Copyright 2015 Mirantis, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+require 'table'
+require 'string'
+
+local afd = require 'afd'
+local consts = require 'gse_constants'
+local lma = require 'lma_utils'
+
+local source_dimension_field
+if read_config('sensu_source_dimension_key') then
+    source_dimension_field = string.format('Fields[%s]', read_config('sensu_source_dimension_key'))
+end
+
+-- mapping GSE statuses to Sensu states
+local sensu_state_map = {
+    [consts.OKAY]=0,
+    [consts.WARN]=1,
+    [consts.CRIT]=2,
+    [consts.DOWN]=2,
+    [consts.UNKW]=2
+}
+
+function process_message()
+
+    local data = {
+	source = nil,
+	name = nil,
+	status = nil,
+	output = nil,
+    }
+
+    local service_name = read_message('Fields[member]')
+    local status = afd.get_status()
+    local alarms = afd.alarms_for_human(afd.extract_alarms())
+    local msgtype = read_message("Type")
+
+    if not service_name or not sensu_state_map[status] or not alarms or not msgtype then
+	return -1
+    end
+
+    local source
+    if msgtype == "heka.sandbox.gse_metric" then
+        if source_dimension_field then
+            source = read_message(source_dimension_field) or "Unknown Source" 
+        else
+            source = "Unknown source"
+        end
+    elseif msgtype == "heka.sandbox.afd_metric" then
+        source = read_message('Fields[hostname]') or read_message('Hostname')
+    else
+        -- Should not happen since we track only AFD and GSE plugins.
+        return -1    
+    end
+
+    data['source'] = source
+    data['name'] = service_name
+    data['status'] = sensu_state_map[status]
+
+    local details = string.format('%s: ', consts.status_label(status))
+
+    if data['status']  ~= 0 then
+      if #alarms == 0 then
+          details = details .. 'No details\n'
+      else
+          for _, alarm in ipairs(alarms) do
+              details = details .. alarm .. '\n'
+          end
+      end
+    end
+
+    data['output'] = details 
+
+    local payload = lma.safe_json_encode(data)
+
+    if not payload then
+       return -1
+    end
+
+    return lma.safe_inject_payload('json', 'sensu', payload)
+end

--- a/heka/map.jinja
+++ b/heka/map.jinja
@@ -82,6 +82,7 @@ RedHat:
     'influxdb_time_precision': default_influxdb_time_precision,
     'influxdb_timeout': default_influxdb_timeout,
     'nagios_port': default_nagios_port,
+    'sensu_port': 3030, 
     'nagios_default_host_alarm_clusters': default_nagios_host_alarm_clusters,
     'poolsize': 100,
     'automatic_starting': default_automatic_starting,

--- a/heka/meta/heka.yml
+++ b/heka/meta/heka.yml
@@ -4,7 +4,6 @@
 {%- from "heka/map.jinja" import aggregator  with context %}
 {%- from "heka/map.jinja" import ceilometer_collector with context %}
 
-
 log_collector:
   filter:
     aggregated_http_metrics:
@@ -446,7 +445,7 @@ aggregator:
       preserve_data: false
       message_matcher: "Type == 'heka.sandbox.gse_metric'"
 {%- endif %}
-{%- if aggregator.influxdb_host is defined or aggregator.nagios_host is defined %}
+{%- if aggregator.influxdb_host is defined or aggregator.nagios_host is defined or aggregator.sensu_host is defined %}
   encoder:
   {%- if aggregator.influxdb_host is defined %}
     influxdb:
@@ -466,8 +465,18 @@ aggregator:
         nagios_host_dimension_key: "{{ aggregator.nagios_host_dimension_key }}"
         {%- endif %}
   {%- endif %}
+  {%- if aggregator.sensu_host is defined %}
+    sensu:
+      engine: sandbox
+      module_file: /usr/share/lma_collector/encoders/status_sensu.lua
+      module_dir: /usr/share/lma_collector/common;/usr/share/heka/lua_modules
+      config:
+        {%- if aggregator.sensu_source_dimension_key is defined %}
+        sensu_source_dimension_key: "{{ aggregator.sensu_source_dimension_key }}"
+        {%- endif %}
+  {%- endif %}
 {%- endif %}
-{%- if aggregator.influxdb_host is defined or aggregator.nagios_host is defined %}
+{%- if aggregator.influxdb_host is defined or aggregator.nagios_host is defined or aggregator.sensu_host is defined %}
   output:
   {%- if aggregator.influxdb_host is defined %}
     influxdb:
@@ -494,6 +503,15 @@ aggregator:
       max_buffer_size: 1048576
       max_file_size: 524288
       full_action: drop
+  {%- endif %}
+  {%- if aggregator.sensu_host is defined %}
+    sensu_alarm_cluster:
+      engine: udp
+      host: "{{ aggregator.sensu_host }}"
+      port: "{{aggregator.sensu_port }}"
+      message_matcher: "(Type == 'heka.sandbox.gse_metric' || Type == 'heka.sandbox.afd_metric') && Fields[no_alerting] == NIL"
+      encoder: sensu_encoder
+      use_buffering: false 
   {%- endif %}
 {%- endif %}
 ceilometer_collector:

--- a/metadata/service/aggregator/output/nagios.yml
+++ b/metadata/service/aggregator/output/nagios.yml
@@ -1,0 +1,5 @@
+parameters:
+  heka:
+    aggregator:
+      nagios_host_dimension_key: nagios_host
+      nagios_host: ${_param:nagios_host}

--- a/metadata/service/aggregator/output/sensu.yml
+++ b/metadata/service/aggregator/output/sensu.yml
@@ -1,0 +1,5 @@
+parameters:
+  heka:
+    aggregator:
+      sensu_source_dimension_key: nagios_host
+      sensu_host: 127.0.0.1

--- a/metadata/service/aggregator/single.yml
+++ b/metadata/service/aggregator/single.yml
@@ -5,11 +5,9 @@ classes:
 parameters:
   _param:
     aggregator_poolsize: 100
-    nagios_host_dimension_key: nagios_host
   heka:
     aggregator:
       automatic_starting: true
       enabled: true
       influxdb_time_precision: ms
       poolsize: ${_param:aggregator_poolsize}
-      nagios_host_dimension_key: ${_param:nagios_host_dimension_key}


### PR DESCRIPTION
The AFD and GSE metrics are sent by the aggregator to local sensu-client.
A sensu-client client should be running on all nodes though (not only the
aggregator) for the sensu integrtion to work correctly.