### PR TITLE
PROD-10359 fixing multiline log parsing for syslog

### DIFF
--- a/heka/files/lua/encoders/syslog.lua
+++ b/heka/files/lua/encoders/syslog.lua
@@ -29,7 +29,7 @@ end
 function process_message()
     local timestamp = os.date("%FT%TZ", read_message('Timestamp') / 1e9)
     local hostname = read_message('Hostname')
-    local msg = read_message('Payload')
+    local msg = string.gsub(read_message('Payload'), "\n", "#")
     local pid = read_message('Pid')
     if pid == nil or pid == 0 then
         pid = '-'


### PR DESCRIPTION
This commit fixes issue when receiving syslog server would split multi-line commit message into two.