### PR TITLE
Add output_limit configuration option for sandbox filter.

### DIFF
--- a/heka/files/toml/filter/sandbox.toml
+++ b/heka/files/toml/filter/sandbox.toml
@@ -16,6 +16,9 @@ ticker_interval = {{ filter.ticker_interval }}
 {%- if filter.hostname is defined %}
 hostname = "{{ filter.hostname }}"
 {%- endif %}
+{%- if filter.output_limit is defined %}
+output_limit = {{ filter.output_limit|int }}
+{%- endif %}
 
 {%- if filter.config is defined %}
 [{{ filter_name }}_filter.config]


### PR DESCRIPTION
In order to make this (https://github.com/salt-formulas/salt-formula-heka/blob/master/heka/meta/heka.yml#L712) work, it needs to be added to the file as well